### PR TITLE
x64dbg.py: Fix for IDA Pro 7.1

### DIFF
--- a/x64dbgida.py
+++ b/x64dbgida.py
@@ -1,8 +1,15 @@
+import idaapi
 if idaapi.IDA_SDK_VERSION <= 695:
-    import idaapi, idautils, json, traceback
+    import idautils
+    import json
+    import traceback
 if idaapi.IDA_SDK_VERSION >= 700:
-    import ida_idaapi, ida_kernwin, json, traceback
-    from idaapi import *
+    import ida_idaapi
+    import ida_kernwin
+    import json
+    import traceback
+    from idc import *
+    from idautils import *
 else:
     pass
 


### PR DESCRIPTION
* Imports idaapi before doing the version check
* Added some imports when version is >= 700 (imports idc and idautils for functions like AskFile and Names)