### PR TITLE
Fixing script for Ida 7.4

### DIFF
--- a/x64dbgida.py
+++ b/x64dbgida.py
@@ -13,6 +13,11 @@ if idaapi.IDA_SDK_VERSION >= 700:
 else:
     pass
 
+try:
+	Askfile
+except NameError:
+	AskFile = ida_kernwin.ask_file
+
 initialized = False
 BPNORMAL = 0
 BPHARDWARE = 1


### PR DESCRIPTION
`AskFile` has apparently been removed from the API and is now replaced by `ida_kernwin.ask_file`.