### PR TITLE
IDA 9.0 fix

### DIFF
--- a/x64dbgida.py
+++ b/x64dbgida.py
@@ -87,7 +87,7 @@ def Breakpoints():
 
 
 def get_file_mask():
-    return "*.dd64" if idaapi.get_inf_structure().is_64bit() else "*.dd32"
+    return "*.dd32" if ida_ida.inf_is_32bit_exactly() else "*.dd64"
 
 
 def do_import():

--- a/x64dbgida.py
+++ b/x64dbgida.py
@@ -87,7 +87,10 @@ def Breakpoints():
 
 
 def get_file_mask():
-    return "*.dd32" if ida_ida.inf_is_32bit_exactly() else "*.dd64"
+    if idaapi.IDA_SDK_VERSION >= 900:
+        return "*.dd32" if ida_ida.inf_is_32bit_exactly() else "*.dd64"
+    else:
+        return "*.dd64" if idaapi.get_inf_structure().is_64bit() else "*.dd32"
 
 
 def do_import():


### PR DESCRIPTION
Update the plugin to fit hex-ray's porting guide for IDA 9.0 (https://hex-rays.com/blog/ida-9-0-sdk-idapython-porting-guides/). 